### PR TITLE
[BBB-53] 스웨거 접속 로그 최소화

### DIFF
--- a/src/main/java/com/erp/erp/global/config/log/LogFilter.java
+++ b/src/main/java/com/erp/erp/global/config/log/LogFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
@@ -18,9 +19,15 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 @Slf4j
 public class LogFilter extends OncePerRequestFilter {
 
-  private long startTime;
-  private final String UUID_KEY = "uuid";
   private final UUID uuid = UUID.randomUUID();
+  private final String UUID_KEY = "uuid";
+
+  private final String SWAGGER_REQUEST = "swagger request";
+  private final String[] SWAGGER_URL = { "/api/swagger-ui/swagger-initializer.js", "/api-docs/swagger-config",
+          "/api/swagger-ui/favicon-32x32.png", "/api-docs", "/api/swagger-ui/index.html" };
+  private boolean isSwagger = false;
+
+  private long startTime;
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -47,6 +54,7 @@ public class LogFilter extends OncePerRequestFilter {
     String queryString = request.getQueryString();
     String uri = request.getRequestURI();
     String uriPlusQueryString = uri + "?" + queryString;
+    isSwaggerRequest(uri);
 
     printRequest(
             request.getMethod(),
@@ -62,6 +70,7 @@ public class LogFilter extends OncePerRequestFilter {
   private void logResponse(ContentCachingResponseWrapper response)
       throws IOException {
     String body = getBody(response.getContentInputStream());
+    if (isSwagger) { body = SWAGGER_REQUEST;}
     printResponse(response.getStatus(), body);
   }
 
@@ -93,5 +102,11 @@ public class LogFilter extends OncePerRequestFilter {
     }
     return clientIp;
   }
+
+  private void isSwaggerRequest(String uri) {
+    isSwagger = Arrays.asList(SWAGGER_URL).contains(uri);
+  }
+
+
 
 }


### PR DESCRIPTION
스웨거에 접속하면 관련 로그가 무분별하게 출력되는 것을 확인

기존에는 이를 제거하기 위해 관련된 모든 url 을 확인 후, 접속 요청에는 별도의 처리를 하였으나
스웨거는 접속 주소가 고정되어있는 것이 아닌 "/api/swagger/[도메인]" 과 같은 형식으로도 접근이 가능하여 관련한 모든 처리는 불가능하다 판단.

고정적으로 접근되는 주소만을 처리하였음

스웨거 관련 키워드가 포함되어있는 주소를 처리하는 방안은 예상치 못한 요청의 가능성을 염두하고 택하지 않음